### PR TITLE
refactor: replace hardcoded URLs with env-based ones

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
+NEXT_PUBLIC_BASE_URL=http://localhost:3000

--- a/src/app/admin/bill-submissions/page.jsx
+++ b/src/app/admin/bill-submissions/page.jsx
@@ -165,7 +165,7 @@ export default function AdminBillSubmissions() {
                 {sub.image_url ? (
                   <div className="mb-2">
                     <a
-                      href={`https://nerlrwamwlhnkacxredz.supabase.co/storage/v1/object/public/receipts/${sub.image_url}`}
+                      href={supabase.storage.from('receipts').getPublicUrl(sub.image_url).data.publicUrl}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-xs text-blue-600 underline"

--- a/src/app/admin/feedback-submissions/page.jsx
+++ b/src/app/admin/feedback-submissions/page.jsx
@@ -123,7 +123,9 @@ export default function AdminFeedbackSubmissions() {
                 {item.context_data?.image_url ? (
                   <p className="mb-2 text-xs">
                     <a
-                      href={`https://nerlrwamwlhnkacxredz.supabase.co/storage/v1/object/public/receipts/${item.context_data.image_url}`}
+                      href={supabase.storage
+                        .from('receipts')
+                        .getPublicUrl(item.context_data.image_url).data.publicUrl}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-blue-600 underline"

--- a/src/app/blog/[slug]/page.jsx
+++ b/src/app/blog/[slug]/page.jsx
@@ -3,6 +3,8 @@ import { supabase } from '@/lib/supabase';
 import BlogPostLayout from '@/components/blog/blog-post-layout';
 import { notFound } from 'next/navigation';
 
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+
 async function getPost(slug) {
   const { data, error } = await supabase
     .from('blog_posts')
@@ -34,7 +36,6 @@ export async function generateMetadata({ params }) {
     };
   }
 
-  const baseUrl = 'https://vetpras.com';
   const canonicalUrl = `${baseUrl}/blog/${params.slug}`;
   const description = post.meta_description || post.excerpt || '';
 
@@ -60,8 +61,6 @@ export async function generateMetadata({ params }) {
 
 // Generate structured data
 function generateStructuredData(post, slug) {
-  const baseUrl = 'https://vetpras.com';
-
   const schemas = [];
 
   // Article schema

--- a/src/app/blog/page.jsx
+++ b/src/app/blog/page.jsx
@@ -3,6 +3,8 @@ import { supabase } from '@/lib/supabase';
 import ContainerConstrained from '@/components/layout/container-constrained';
 import Link from 'next/link';
 
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+
 export const metadata = {
   title: 'Blog | Vetpras',
   description:
@@ -11,7 +13,7 @@ export const metadata = {
     title: 'Vetpras Blog - Pet Care Insights & Veterinary Resources',
     description:
       'Stay informed with our latest articles on pet health, veterinary costs, and making the best decisions for your pet.',
-    url: 'https://vetpras.com/blog',
+    url: `${baseUrl}/blog`,
     siteName: 'Vetpras',
     type: 'website',
     locale: 'en_CA',

--- a/src/app/cost/[service-slug]/page.jsx
+++ b/src/app/cost/[service-slug]/page.jsx
@@ -6,6 +6,8 @@ import { notFound } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+
 async function getPriceGuide(slug) {
   const { data, error } = await supabase
     .from('blog_posts')
@@ -38,7 +40,6 @@ export async function generateMetadata({ params }) {
     };
   }
 
-  const baseUrl = 'https://vetpras.com';
   const canonicalUrl = guide.canonical_url || `${baseUrl}/cost/${params['service-slug']}`;
 
   const description =
@@ -110,8 +111,6 @@ export async function generateMetadata({ params }) {
 
 // Generate JSON-LD structured data
 function generateStructuredData(guide, slug) {
-  const baseUrl = 'https://vetpras.com';
-
   const structuredData = {
     '@context': 'https://schema.org',
     '@type': 'Article',

--- a/src/app/cost/page.jsx
+++ b/src/app/cost/page.jsx
@@ -3,6 +3,8 @@ import { supabase } from '@/lib/supabase';
 import ContainerConstrained from '@/components/layout/container-constrained';
 import Link from 'next/link';
 
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+
 export const metadata = {
   title: 'Veterinary Cost Guides | Pet Care Pricing in Canada | Vetpras',
   description:
@@ -11,7 +13,7 @@ export const metadata = {
     title: 'Veterinary Cost Guides - Transparent Pet Care Pricing',
     description:
       'Complete pricing guides for veterinary services including vaccinations, surgeries, dental care, and emergency visits.',
-    url: 'https://vetpras.com/cost',
+    url: `${baseUrl}/cost`,
     siteName: 'Vetpras',
     type: 'website',
     locale: 'en_CA',

--- a/src/app/find/[city-slug]/page.jsx
+++ b/src/app/find/[city-slug]/page.jsx
@@ -6,6 +6,8 @@ import { notFound } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+
 async function getCityHub(slug) {
   const { data, error } = await supabase
     .from('blog_posts')
@@ -55,7 +57,6 @@ export async function generateMetadata({ params }) {
     };
   }
 
-  const baseUrl = 'https://vetpras.com';
   const canonicalUrl = hub.canonical_url || `${baseUrl}/find/${params['city-slug']}`;
 
   // Format city name for display
@@ -129,7 +130,6 @@ export async function generateMetadata({ params }) {
 
 // Generate JSON-LD structured data for local SEO
 function generateStructuredData(hub, slug) {
-  const baseUrl = 'https://vetpras.com';
   const cityName = hub.target_city || hub.title.replace(' Veterinarians', '').replace(' Vets', '');
   const provinceName = hub.target_province ? provinceNames[hub.target_province] : '';
   const fullLocation = provinceName ? `${cityName}, ${provinceName}` : cityName;

--- a/src/app/find/page.jsx
+++ b/src/app/find/page.jsx
@@ -3,6 +3,8 @@ import { supabase } from '@/lib/supabase';
 import ContainerConstrained from '@/components/layout/container-constrained';
 import Link from 'next/link';
 
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+
 export const metadata = {
   title: 'Find Veterinarians by City | Vet Clinics Across Canada | Vetpras',
   description:
@@ -11,7 +13,7 @@ export const metadata = {
     title: 'Find Veterinarians Across Canada - City Directory',
     description:
       'Discover veterinary clinics in major Canadian cities. Compare services, read guides, and find the right vet for your pet.',
-    url: 'https://vetpras.com/find',
+    url: `${baseUrl}/find`,
     siteName: 'Vetpras',
     type: 'website',
     locale: 'en_CA',

--- a/src/app/learn/[topic-slug]/page.jsx
+++ b/src/app/learn/[topic-slug]/page.jsx
@@ -6,6 +6,8 @@ import { notFound } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+
 async function getExplainer(slug) {
   const { data, error } = await supabase
     .from('blog_posts')
@@ -38,7 +40,6 @@ export async function generateMetadata({ params }) {
     };
   }
 
-  const baseUrl = 'https://vetpras.com';
   const canonicalUrl = `${baseUrl}/learn/${params['topic-slug']}`;
 
   const description =
@@ -219,14 +220,14 @@ export default async function ExplainerPage({ params }) {
         name: 'Vetpras',
         logo: {
           '@type': 'ImageObject',
-          url: 'https://vetpras.com/images/vetpras-logo.svg',
+          url: `${baseUrl}/images/vetpras-logo.svg`,
         },
       },
       datePublished: explainer.published_date,
       dateModified: explainer.updated_at || explainer.published_date,
       mainEntityOfPage: {
         '@type': 'WebPage',
-        '@id': `https://vetpras.com/learn/${explainer.slug}`,
+        '@id': `${baseUrl}/learn/${explainer.slug}`,
       },
       keywords: explainer.target_keywords?.join(', '),
       educationalLevel: 'beginner',
@@ -251,19 +252,19 @@ export default async function ExplainerPage({ params }) {
           '@type': 'ListItem',
           position: 1,
           name: 'Home',
-          item: 'https://vetpras.com',
+          item: baseUrl,
         },
         {
           '@type': 'ListItem',
           position: 2,
           name: 'Learning Center',
-          item: 'https://vetpras.com/learn',
+          item: `${baseUrl}/learn`,
         },
         {
           '@type': 'ListItem',
           position: 3,
           name: explainer.title,
-          item: `https://vetpras.com/learn/${explainer.slug}`,
+          item: `${baseUrl}/learn/${explainer.slug}`,
         },
       ],
     };

--- a/src/app/terms-and-conditions/page.jsx
+++ b/src/app/terms-and-conditions/page.jsx
@@ -7,6 +7,8 @@ export const metadata = {
     'Official Rules for the Vetpras Monthly Draw (Canada, excluding Quebec unless a full French version is published).',
 };
 
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+
 export default function MonthlyDrawTermsPage() {
   return (
     <div className="pt-24 pb-16">
@@ -67,7 +69,7 @@ export default function MonthlyDrawTermsPage() {
               <li>
                 During a Monthly Entry Period, submit an itemized veterinary bill for{' '}
                 <strong>dog</strong> care via{' '}
-                <span className="whitespace-nowrap">[https://www.vetpras.com/submit-bill]</span> or
+                <span className="whitespace-nowrap">[{`${baseUrl}/submit-bill`}]</span> or
                 the in-app flow.
               </li>
               <li>
@@ -88,7 +90,7 @@ export default function MonthlyDrawTermsPage() {
             <ul className="mt-2 list-inside list-disc space-y-2">
               <li>
                 During a Monthly Entry Period, visit{' '}
-                <span className="whitespace-nowrap">[https://www.vetpras.com/submit-bill]</span> and
+                <span className="whitespace-nowrap">[{`${baseUrl}/submit-bill`}]</span> and
                 submit your full name, mailing address, email, and a short statement (25–50 words)
                 about your dog.
               </li>


### PR DESCRIPTION
## Summary
- Use `getPublicUrl` for receipt and feedback image links
- Centralize site base URL via `NEXT_PUBLIC_BASE_URL`
- Document new `NEXT_PUBLIC_BASE_URL` environment variable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbe81626208320bdbb73b63430ba52