### PR TITLE
Check Supabase env vars before client creation

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,17 +1,16 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient } from '@supabase/supabase-js';
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-// Export a ready client (most of your code likely imports { supabase })
-export const supabase = createClient(url ?? '', anon ?? '')
-
-// Also export a getter that throws with a clear message if envs are missing
-export function getSupabase() {
-  if (!url || !anon) {
-    throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY')
-  }
-  return supabase
+if (!url) {
+  throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL environment variable');
 }
 
-export default supabase
+if (!anon) {
+  throw new Error('Missing NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable');
+}
+
+export const supabase = createClient(url, anon);
+
+export default supabase;


### PR DESCRIPTION
## Summary
- ensure Supabase client only initializes when `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are set

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbe96673b8832094f0ec7b4db1de37