### PR TITLE
Centralize admin role checks

### DIFF
--- a/src/app/admin/bill-submissions/page.jsx
+++ b/src/app/admin/bill-submissions/page.jsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase';
+import { isAdmin } from '@/lib/is-admin';
 import ContainerConstrained from '@/components/layout/container-constrained';
 import Pagination from '@/components/clinics/pagination';
 
@@ -35,11 +36,10 @@ export default function AdminBillSubmissions() {
 
       const user = currentSession.user;
       console.log('👤 Logged in as:', user?.email);
-      const isAdmin =
-        user?.email === 'jonathan.e.g.warr@gmail.com' || user?.email === 'negamiri@gmail.com';
+      const isAdminUser = isAdmin(user);
 
-      console.log('🛡 isAdmin:', isAdmin);
-      if (!isAdmin) {
+      console.log('🛡 isAdmin:', isAdminUser);
+      if (!isAdminUser) {
         console.log('🚫 Not admin, redirecting to /');
         router.replace('/');
       }

--- a/src/app/admin/dashboard/page.jsx
+++ b/src/app/admin/dashboard/page.jsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabase';
+import { isAdmin } from '@/lib/is-admin';
 import { useRouter } from 'next/navigation';
 
 export default function AdminDashboardPage() {
@@ -35,12 +36,11 @@ export default function AdminDashboardPage() {
     const user = session.user;
     console.log('👤 Logged in as:', user?.email);
 
-    const isAdmin =
-      user?.email === 'jonathan.e.g.warr@gmail.com' || user?.email === 'negamiri@gmail.com';
+    const isAdminUser = isAdmin(user);
 
-    console.log('🛡 isAdmin:', isAdmin);
+    console.log('🛡 isAdmin:', isAdminUser);
 
-    if (!isAdmin) {
+    if (!isAdminUser) {
       console.log('🚫 Not admin, redirecting to /');
       router.replace('/');
     }

--- a/src/app/admin/feedback-submissions/page.jsx
+++ b/src/app/admin/feedback-submissions/page.jsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase';
+import { isAdmin } from '@/lib/is-admin';
 import ContainerConstrained from '@/components/layout/container-constrained';
 import Pagination from '@/components/clinics/pagination';
 
@@ -33,11 +34,10 @@ export default function AdminFeedbackSubmissions() {
 
       const user = currentSession.user;
       console.log('👤 Logged in as:', user?.email);
-      const isAdmin =
-        user?.email === 'jonathan.e.g.warr@gmail.com' || user?.email === 'negamiri@gmail.com';
+      const isAdminUser = isAdmin(user);
 
-      console.log('🛡 isAdmin:', isAdmin);
-      if (!isAdmin) {
+      console.log('🛡 isAdmin:', isAdminUser);
+      if (!isAdminUser) {
         console.log('🚫 Not admin, redirecting to /');
         router.replace('/');
       }

--- a/src/app/admin/login/page.jsx
+++ b/src/app/admin/login/page.jsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSession } from '@supabase/auth-helpers-react';
 import { supabase } from '@/lib/supabase';
+import { isAdmin } from '@/lib/is-admin';
 
 export default function AdminLoginPage() {
   const router = useRouter();
@@ -15,9 +16,9 @@ export default function AdminLoginPage() {
   // 🚀 If user is already logged in and admin, send them to the dashboard
   useEffect(() => {
     const user = session?.user;
-    const isAdmin = user?.email === 'you@example.com' || user?.email === 'negar@example.com';
+    const isAdminUser = isAdmin(user);
 
-    if (session && isAdmin) {
+    if (session && isAdminUser) {
       router.push('/admin/dashboard');
     }
   }, [session, router]);

--- a/src/lib/is-admin.js
+++ b/src/lib/is-admin.js
@@ -1,0 +1,14 @@
+export function isAdmin(userOrEmail) {
+  const email =
+    typeof userOrEmail === 'string' ? userOrEmail : userOrEmail?.email;
+
+  if (!email) return false;
+
+  const list = process.env.NEXT_PUBLIC_ADMIN_EMAILS || '';
+  const admins = list
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+
+  return admins.includes(email.toLowerCase());
+}


### PR DESCRIPTION
## Summary
- add `isAdmin` helper backed by `NEXT_PUBLIC_ADMIN_EMAILS`
- refactor admin pages to use centralized role checks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbeaaa78e88320b04898bf3d6c0fe9