### PR TITLE
refactor: replace console logs with environment-aware logger

### DIFF
--- a/src/app/admin/bill-submissions/page.jsx
+++ b/src/app/admin/bill-submissions/page.jsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase';
 import ContainerConstrained from '@/components/layout/container-constrained';
 import Pagination from '@/components/clinics/pagination';
+import { logger } from '@/lib/utils/logger';
 
 export default function AdminBillSubmissions() {
   const router = useRouter();
@@ -28,19 +29,19 @@ export default function AdminBillSubmissions() {
       setReady(true);
 
       if (!currentSession) {
-        console.log('❌ No session, redirecting to login');
+        logger.log('❌ No session, redirecting to login');
         router.replace('/admin/login');
         return;
       }
 
       const user = currentSession.user;
-      console.log('👤 Logged in as:', user?.email);
+      logger.log('👤 Logged in as:', user?.email);
       const isAdmin =
         user?.email === 'jonathan.e.g.warr@gmail.com' || user?.email === 'negamiri@gmail.com';
 
-      console.log('🛡 isAdmin:', isAdmin);
+      logger.log('🛡 isAdmin:', isAdmin);
       if (!isAdmin) {
-        console.log('🚫 Not admin, redirecting to /');
+        logger.log('🚫 Not admin, redirecting to /');
         router.replace('/');
       }
     };

--- a/src/app/admin/dashboard/page.jsx
+++ b/src/app/admin/dashboard/page.jsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabase';
 import { useRouter } from 'next/navigation';
+import { logger } from '@/lib/utils/logger';
 
 export default function AdminDashboardPage() {
   const [session, setSession] = useState(null);
@@ -27,21 +28,21 @@ export default function AdminDashboardPage() {
     if (!ready) return;
 
     if (!session) {
-      console.log('❌ No session, redirecting to login');
+      logger.log('❌ No session, redirecting to login');
       router.replace('/admin/login');
       return;
     }
 
     const user = session.user;
-    console.log('👤 Logged in as:', user?.email);
+    logger.log('👤 Logged in as:', user?.email);
 
     const isAdmin =
       user?.email === 'jonathan.e.g.warr@gmail.com' || user?.email === 'negamiri@gmail.com';
 
-    console.log('🛡 isAdmin:', isAdmin);
+    logger.log('🛡 isAdmin:', isAdmin);
 
     if (!isAdmin) {
-      console.log('🚫 Not admin, redirecting to /');
+      logger.log('🚫 Not admin, redirecting to /');
       router.replace('/');
     }
   }, [ready, session, router]);

--- a/src/app/admin/feedback-submissions/page.jsx
+++ b/src/app/admin/feedback-submissions/page.jsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase';
 import ContainerConstrained from '@/components/layout/container-constrained';
 import Pagination from '@/components/clinics/pagination';
+import { logger } from '@/lib/utils/logger';
 
 export default function AdminFeedbackSubmissions() {
   const router = useRouter();
@@ -26,19 +27,19 @@ export default function AdminFeedbackSubmissions() {
       setReady(true);
 
       if (!currentSession) {
-        console.log('❌ No session, redirecting to login');
+        logger.log('❌ No session, redirecting to login');
         router.replace('/admin/login');
         return;
       }
 
       const user = currentSession.user;
-      console.log('👤 Logged in as:', user?.email);
+      logger.log('👤 Logged in as:', user?.email);
       const isAdmin =
         user?.email === 'jonathan.e.g.warr@gmail.com' || user?.email === 'negamiri@gmail.com';
 
-      console.log('🛡 isAdmin:', isAdmin);
+      logger.log('🛡 isAdmin:', isAdmin);
       if (!isAdmin) {
-        console.log('🚫 Not admin, redirecting to /');
+        logger.log('🚫 Not admin, redirecting to /');
         router.replace('/');
       }
     };

--- a/src/components/system/session-handler.jsx
+++ b/src/components/system/session-handler.jsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase';
+import { logger } from '@/lib/utils/logger';
 
 export default function SessionHandler() {
   const router = useRouter();
@@ -22,7 +23,7 @@ export default function SessionHandler() {
         if (error) {
           console.error('❌ setSession error:', error.message);
         } else {
-          console.log('✅ Session saved to Supabase');
+          logger.log('✅ Session saved to Supabase');
           router.replace('/admin/dashboard');
         }
       });

--- a/src/lib/utils/logger.js
+++ b/src/lib/utils/logger.js
@@ -1,0 +1,15 @@
+export const logger = {
+  log: (...args) => {
+    if (process.env.NODE_ENV === 'development') {
+      console.log(...args);
+    }
+  },
+  warn: (...args) => {
+    if (process.env.NODE_ENV === 'development') {
+      console.warn(...args);
+    }
+  },
+  error: (...args) => {
+    console.error(...args);
+  },
+};


### PR DESCRIPTION
## Summary
- add simple logger utility respecting NODE_ENV
- use logger instead of console.log in session handler and admin pages
- clean up remaining debug logs in admin and system components

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbec402a288320b6940de3f5faf5ae